### PR TITLE
Update SDKs.md

### DIFF
--- a/AT_Protocol/SDKs.md
+++ b/AT_Protocol/SDKs.md
@@ -12,7 +12,7 @@ dateCreated: 2024-09-26T16:04:32.739Z
 Below is a list of all [ATProto](/AT_Protocol) SDKs, including official and third-party implementations.
 - [Dart SDK (unofficial)*Community SDK, maintained by @shinyakato.dev*](/AT_Protocol/SDKs/Dart)
 - [Golang SDK*Official SDK, maintained by Bluesky Social*](/AT_Protocol/SDKs/Golang)
-- [Python SDK (unofficial)*Community SDK, maintained by @marshal.dev*](/AT_Protocol/SDKs/Golang)
+- [Python SDK (unofficial)*Community SDK, maintained by @marshal.dev*](/AT_Protocol/SDKs/Python)
 - [Typescript SDK*Official SDK, maintained by Bluesky Social*](/AT_Protocol/SDKs/Typescript)
 {.links-list}
 


### PR DESCRIPTION
Python sdk link was mistakenly pointing to the golang page